### PR TITLE
Update election timeline and CEP content

### DIFF
--- a/app/[lang]/(marketing)/timeline/page.tsx
+++ b/app/[lang]/(marketing)/timeline/page.tsx
@@ -1,94 +1,174 @@
-import type { Metadata } from "next"
-import Link from "next/link"
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
 
 export const metadata: Metadata = {
-  title: "Election Timeline",
-  description: "Key dates and milestones in Haiti's 2026 electoral process.",
+  title: 'Election Timeline',
+  description: "Key dates in Haiti's official 2026-2027 electoral calendar.",
 }
 
 const timelineItems = [
   {
-    date: "2024",
-    title: "Transitional Presidential Council Formed",
+    date: 'September-December 2024',
+    title: 'Provisional Electoral Council Reconstituted',
     description:
-      "A transitional council with representatives from major political parties and civil society was established to oversee a path toward elections.",
-    category: "Government",
+      'Seven members of a new Provisional Electoral Council (CEP) were appointed in September and sworn in in October. The final two members joined in December, completing the nine-member body.',
+    category: 'Institution',
   },
   {
-    date: "Early 2025",
-    title: "Electoral Framework Under Review",
+    date: 'March 2-12, 2026',
+    title: 'Political Parties Registered',
     description:
-      "The Conseil Electoral Provisoire (CEP) began formal review of the electoral framework and registration requirements.",
-    category: "Electoral Process",
+      'The CEP accepted political-party registrations. On July 9, it published its definitive review: 316 parties were approved and four were not approved.',
+    category: 'Completed',
   },
   {
-    date: "March 2 - 12 2026",
-    title: "Political Party Registration",
+    date: 'June 2, 2026',
+    title: 'Revised Electoral Decree Adopted',
     description:
-      "The CEP opened registration for political parties, marking the formal start of the 2026 electoral process.",
-    category: "Electoral Process",
+      'A new electoral decree established the legal framework for the process. A decree adopted July 2 later amended some provisions.',
+    category: 'Legal Framework',
   },
   {
-    date: "TBD",
-    title: "Voter Registration Period",
+    date: 'July 3-August 18, 2026',
+    title: 'Observers and Journalists Accredited',
     description:
-      "Official voter registration dates to be announced by the CEP. Diaspora participation requirements will be published at this time.",
-    category: "Registration",
+      'The official calendar sets this accreditation window. On August 11, the CEP invited media and election-observation organizations to submit applications.',
+    category: 'In Progress',
+  },
+  {
+    date: 'July 13-August 14, 2026',
+    title: 'Political Alliances Registered',
+    description:
+      'The calendar provides for the registration of political groupings and regroupings. The CEP reported 18 groupings registered and approved 15 of them; registration of regroupings runs August 10-14.',
+    category: 'In Progress',
+  },
+  {
+    date: 'July 20-October 13, 2026',
+    title: 'Voter Registration',
+    description:
+      "The CEP launched voter registration on July 20 and is progressively opening Centres d'inscription et de vote (CIV) across the country. Registration on the electoral roll is required to vote.",
+    category: 'In Progress',
+  },
+  {
+    date: 'July 27, 2026',
+    title: 'New 2026-2027 Calendar Published',
+    description:
+      'The CEP replaced the earlier August and December election dates with a revised schedule extending through March 2027.',
+    category: 'Official Update',
+  },
+  {
+    date: 'August 20-October 2, 2026',
+    title: 'Candidate Registration',
+    description: 'Candidates for the upcoming elections are scheduled to file during this period.',
+    category: 'Upcoming',
     pending: true,
   },
   {
-    date: "TBD",
-    title: "Campaign Period",
+    date: 'October 5-December 12, 2026',
+    title: 'First-Round Campaign',
     description:
-      "Official campaign period dates to be set by the CEP following confirmation of the electoral calendar.",
-    category: "Campaigns",
+      'The campaign period for the first round of the presidential and legislative elections is scheduled to run for 69 days.',
+    category: 'Upcoming',
     pending: true,
   },
   {
-    date: "30 August 2026",
-    title: "General Election",
-    description:
-      "Haiti's government has pledged to hold a general election on this date, as part of a revised electoral calendar approved by the Transitional Presidential Council. Voters will elect the president, all 119 seats in the Chamber of Deputies, all 30 Senate seats, and local and municipal offices.",
-    category: "Election",
+    date: 'November 13, 2026',
+    title: 'Electoral Lists Published',
+    description: 'The CEP is scheduled to publish the electoral lists 30 days before voting.',
+    category: 'Upcoming',
+    pending: true,
   },
   {
-    date: "6 December 2026",
-    title: "Presidential Runoff",
+    date: 'December 13, 2026',
+    title: 'First-Round Election',
     description:
-      "A runoff election is scheduled if no presidential candidate wins an outright majority in the first round.",
-    category: "Election",
+      'The first round of the presidential and legislative elections is scheduled alongside a popular vote on proposed constitutional changes.',
+    category: 'Election',
+    pending: true,
+  },
+  {
+    date: 'December 19, 2026-January 9, 2027',
+    title: 'First-Round Results and Challenges',
+    description:
+      'Preliminary presidential and legislative results are scheduled for December 19, followed by a challenge period and final results on January 9.',
+    category: 'Results',
+    pending: true,
+  },
+  {
+    date: 'January 10-February 20, 2027',
+    title: 'Second-Round Campaign',
+    description:
+      'The campaign for any second-round presidential and legislative contests, as well as territorial elections, is scheduled during this period.',
+    category: 'Upcoming',
+    pending: true,
+  },
+  {
+    date: 'February 21, 2027',
+    title: 'Second Round and Territorial Elections',
+    description:
+      'The second round of the presidential and legislative elections, if required, and elections for territorial collectivities are scheduled for this date.',
+    category: 'Election',
+    pending: true,
+  },
+  {
+    date: 'March 7-12, 2027',
+    title: 'Final Results',
+    description:
+      'Final second-round presidential and legislative results are scheduled for March 7, followed by final territorial-election results on March 12.',
+    category: 'Results',
+    pending: true,
   },
 ]
+
+const cepCalendarUrl =
+  'https://cephaiti.ht/publication-officielle-du-calendrier-electoral-2026-2027/'
+const cepUpdatesUrl = 'https://cephaiti.ht/notes-communiques/'
 
 export default function TimelinePage() {
   return (
     <div className="container max-w-3xl py-12 md:py-20">
       <div className="mb-10">
+        <div className="mb-4 text-sm font-medium text-muted-foreground">
+          Updated August 11, 2026
+        </div>
         <h1 className="font-heading text-4xl font-bold">Election Timeline</h1>
         <p className="mt-3 text-muted-foreground">
-          Key dates and milestones in Haiti&apos;s 2026 electoral process. This page is updated as
-          official information becomes available.
+          Key milestones in Haiti&apos;s official 2026-2027 electoral calendar, including operations
+          already underway and dates announced by the Conseil électoral provisoire (CEP).
+        </p>
+      </div>
+
+      <div className="mb-10 rounded-lg border border-amber-500/30 bg-amber-500/5 p-5">
+        <h2 className="font-semibold">The schedule has changed</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The previously announced August 30 and December 6, 2026 election dates are no longer
+          current. On July 27, the CEP scheduled the first round for December 13, 2026 and the
+          second round for February 21, 2027. The CEP says meeting these dates depends on an
+          acceptable security environment and sufficient funding.
         </p>
       </div>
 
       <div className="relative space-y-0 before:absolute before:left-4 before:top-2 before:h-[calc(100%-1rem)] before:w-px before:bg-border">
-        {timelineItems.map((item, index) => (
-          <div key={index} className="relative pl-12 pb-10">
-            <div className={cn(
-              "absolute left-2.5 top-1 size-3 -translate-x-1/2 rounded-full border-2 border-background",
-              item.pending ? "bg-muted-foreground/40" : "bg-primary"
-            )} />
+        {timelineItems.map((item) => (
+          <div key={`${item.date}-${item.title}`} className="relative pb-10 pl-12">
+            <div
+              className={cn(
+                'absolute left-2.5 top-1 size-3 -translate-x-1/2 rounded-full border-2 border-background',
+                item.pending ? 'bg-muted-foreground/40' : 'bg-primary'
+              )}
+            />
             <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
               <span className="font-semibold">{item.title}</span>
-              <span className={cn(
-                "rounded-full px-2 py-0.5 text-xs font-medium",
-                item.pending
-                  ? "bg-muted text-muted-foreground"
-                  : "bg-primary/10 text-primary"
-              )}>
-                {item.pending ? "Pending" : item.category}
+              <span
+                className={cn(
+                  'rounded-full px-2 py-0.5 text-xs font-medium',
+                  item.pending ? 'bg-muted text-muted-foreground' : 'bg-primary/10 text-primary'
+                )}
+              >
+                {item.category}
               </span>
             </div>
             <p className="mt-0.5 text-sm font-medium text-muted-foreground">{item.date}</p>
@@ -98,15 +178,31 @@ export default function TimelinePage() {
       </div>
 
       <div className="mt-4 rounded-lg border p-4 text-sm text-muted-foreground">
-        Timeline is based on publicly available information and is subject to change.
-        Sources include CEP official communications and credible Haitian and international news outlets.
+        <p>
+          This timeline is based primarily on the CEP&apos;s official calendar and public notices.
+          Dates may change if the CEP issues a new calendar.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">
+          <a
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            href={cepCalendarUrl}
+          >
+            Official 2026-2027 calendar
+          </a>
+          <a
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            href={cepUpdatesUrl}
+          >
+            Latest CEP notices
+          </a>
+        </div>
       </div>
 
-      <div className="mt-8 flex gap-4">
-        <Link href="/eligibility" className={cn(buttonVariants(), "w-fit")}>
+      <div className="mt-8 flex flex-wrap gap-4">
+        <Link href="/eligibility" className={cn(buttonVariants(), 'w-fit')}>
           Check Eligibility
         </Link>
-        <Link href="/resources" className={cn(buttonVariants({ variant: "outline" }), "w-fit")}>
+        <Link href="/resources" className={cn(buttonVariants({ variant: 'outline' }), 'w-fit')}>
           Resources
         </Link>
       </div>

--- a/app/[lang]/(marketing)/why-this-election-matters/page.tsx
+++ b/app/[lang]/(marketing)/why-this-election-matters/page.tsx
@@ -1,153 +1,174 @@
-import type { Metadata } from 'next';
-import Link from 'next/link';
+import type { Metadata } from 'next'
+import Link from 'next/link'
 
-
-
-import { cn } from '@/lib/utils';
-import { buttonVariants } from '@/components/ui/button';
-
-
-
-
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
 
 export const metadata: Metadata = {
   title: 'Why This Election Matters',
   description:
-    "The historical context behind Haiti's 2026 election and what is at stake for the country.",
+    "Why Haiti's 2026-2027 electoral process matters and what the latest CEP updates mean.",
 }
+
+const cepCalendarUrl =
+  'https://cephaiti.ht/publication-officielle-du-calendrier-electoral-2026-2027/'
+const cepUpdatesUrl = 'https://cephaiti.ht/notes-communiques/'
 
 export default function WhyThisElectionMattersPage() {
   return (
     <article className="container max-w-3xl py-12 md:py-20">
       <header className="mb-12">
-        <div className="mb-4 text-sm font-medium text-muted-foreground">Historical Context</div>
+        <div className="mb-4 text-sm font-medium text-muted-foreground">
+          Updated August 11, 2026
+        </div>
         <h1 className="font-heading text-4xl font-bold leading-tight sm:text-5xl">
           Why This Election Matters
         </h1>
-        <p className="mt-4 text-xl text-muted-foreground leading-relaxed">
-          Haiti has not completed a full, legitimate democratic transition in nearly a decade. The
-          2026 election represents a rare, consequential opportunity.
+        <p className="mt-4 text-xl leading-relaxed text-muted-foreground">
+          Haiti is preparing for its first national vote in a decade. The CEP&apos;s new calendar
+          makes the path more concrete, but security, funding, and public trust will determine
+          whether the process succeeds.
         </p>
       </header>
 
-      <div className="prose prose-slate dark:prose-invert max-w-none space-y-8">
+      <div className="prose prose-slate max-w-none space-y-8 dark:prose-invert">
         <section>
           <h2>A Decade Without National Elections</h2>
-
           <p>
-            Haiti’s most recent national election cycle began in 2015, covering the presidency,
-            parliament, and local offices. During this process, Jovenel Moïse was declared the
-            winner of the presidential race. However, the results were widely contested, and the
-            presidential election was ultimately annulled following allegations of fraud and
-            irregularities, along with broader disruptions affecting legislative and local races.
+            Haiti&apos;s last national election cycle began in 2015. After the initial presidential
+            result was annulled amid allegations of fraud and irregularities, a rerun was held in
+            2016. Jovenel Moïse won that vote and took office in 2017.
           </p>
-
           <p>
-            After a period of political transition under interim leadership, new elections were held
-            in 2016. Moïse again ran and won the presidency, taking office in 2017. Parliamentary
-            elections were also completed during this period, but no subsequent national elections
-            have been held to renew most elected offices.
+            No subsequent national elections renewed the country&apos;s elected institutions. As
+            mandates expired, Haiti was left without a functioning national legislature and with
+            many local offices vacant or managed through interim appointments. Moïse&apos;s
+            assassination on July 7, 2021 deepened the institutional crisis, and national authority
+            has since remained in transitional, unelected hands.
           </p>
-
           <p>
-            Over time, the mandates of elected officials at all levels expired without new elections
-            being held, leaving Haiti without a functioning parliament and with many local positions
-            vacant or filled through interim arrangements.
+            The 2026-2027 process is therefore not a routine election. It is an attempt to restore
+            representative institutions after years without nationally elected government.
           </p>
+        </section>
 
+        <section>
+          <h2>What Has Changed</h2>
           <p>
-            On July 7, 2021, Moïse was assassinated, creating a leadership vacuum. Since then, Haiti
-            has been governed by unelected transitional authorities.
+            The electoral process has moved beyond preliminary planning. A revised electoral decree
+            was adopted on June 2, 2026 and later amended. The CEP published its definitive list of
+            political parties on July 9, launched voter registration on July 20, and published a new
+            2026-2027 electoral calendar on July 27.
           </p>
-
           <p>
-            The upcoming vote represents a critical opportunity to restore elected governance and
-            democratic legitimacy across all levels of the state.
+            Under that calendar, the first round of presidential and legislative elections is
+            scheduled for December 13, 2026, together with a popular vote on proposed constitutional
+            changes. Any second round, along with elections for territorial collectivities, is
+            scheduled for February 21, 2027. Final results are expected in March 2027.
+          </p>
+          <p>
+            Recent CEP activity also includes the progressive opening of voter-registration centers,
+            the review of political alliances, and the launch of accreditation for journalists and
+            election observers. These are tangible operational steps, not only promised dates.
           </p>
         </section>
 
         <section>
           <h2>What Is at Stake</h2>
           <p>
-            The stakes of this election extend beyond who wins. What is fundamentally at stake is
-            whether Haiti can restore the basic constitutional framework that makes governance
-            accountable to the people.
+            The election will shape the presidency, the legislature, and local government. More
+            fundamentally, it will test whether Haiti can rebuild institutions that answer to voters
+            and create a lawful basis for governing through the country&apos;s security,
+            humanitarian, and economic crises.
           </p>
-          <p>A credible election outcome would establish:</p>
+          <p>A credible process could provide:</p>
           <ul>
-            <li>A president with a legitimate popular mandate</li>
-            <li>A government capable of negotiating with international partners</li>
-            <li>A precedent that democratic transfers of power are possible in Haiti</li>
-            <li>A foundation for addressing the security and humanitarian crisis</li>
+            <li>Elected national and local authorities with a popular mandate</li>
+            <li>A restored legislature able to exercise representation and oversight</li>
+            <li>A constitutional path away from prolonged transitional rule</li>
+            <li>A stronger basis for public accountability and international cooperation</li>
           </ul>
-        </section>
-
-        <section>
-          <h2>The Role of the Haitian Diaspora</h2>
-
           <p>
-            The Haitian diaspora is one of the most significant forces in Haitian civil society.
-            Remittances from Haitians abroad account for approximately 20% to 25% of Haiti’s GDP,
-            making it one of the highest remittance-dependent economies in the world. Diaspora
-            Haitians maintain deep ties to the country through family, culture, and investment.
-          </p>
-
-          <p>
-            Legally, the Haitian constitution extends citizenship and its associated rights to all
-            children of Haitian nationals, regardless of where they were born. This means millions
-            of Haitians in the United States, Canada, France, and elsewhere may hold the right to
-            participate.
-          </p>
-
-          <p>
-            What has historically been missing is access to clear, trustworthy information about how
-            to exercise that right. Vwa was built to address that gap.
+            Credibility depends on more than holding a vote. Voters and candidates must be able to
+            participate safely, election administration must be impartial, and results must be
+            transparent and open to lawful challenge.
           </p>
         </section>
 
         <section>
-          <h2>What We Know and Do Not Know</h2>
+          <h2>The Calendar Is Official, but Conditional</h2>
           <p>
-            The full mechanics of diaspora participation are still being determined by the Conseil
-            Electoral Provisoire (CEP). We will update this page as official guidance is published.
-            What is clear:
+            The new dates replace the earlier plan for elections on August 30 and December 6, 2026.
+            In publishing the revised calendar, the CEP explicitly stated that meeting its deadlines
+            depends on an acceptable security environment and the availability of sufficient
+            funding.
           </p>
-          <ul>
-            <li>The constitutional right to citizenship is not in question</li>
-            <li>Documentation requirements will likely apply</li>
-            <li>Early preparation is strongly advisable</li>
-            <li>The registration window may be limited</li>
-          </ul>
+          <p>
+            That condition matters. The calendar is the current official plan, not a guarantee. Vwa
+            will distinguish between scheduled milestones, completed steps, and any future changes
+            announced by the CEP.
+          </p>
+        </section>
+
+        <section>
+          <h2>Voter Registration and the Diaspora</h2>
+          <p>
+            The CEP says a voter must be at least 18, be registered on the electoral roll, hold a
+            national identification card (CIN), and retain full civil and political rights. Voter
+            registration began on July 20 and is scheduled to continue through October 13, 2026,
+            with registration-and-voting centers opening progressively across Haiti.
+          </p>
+          <p>
+            Haitians abroad remain deeply connected to the country through family, civic life,
+            investment, and remittances. However, citizenship alone should not be treated as
+            confirmation that a person can vote from abroad. As of this update, the CEP has not
+            published a complete, operational overseas voting process. Diaspora voters should wait
+            for official instructions on registration locations, required documents, and where a
+            ballot may be cast.
+          </p>
         </section>
 
         <section>
           <h2>A Note on Partisanship</h2>
           <p>
             Vwa is a nonpartisan platform. We do not endorse any candidate, party, or political
-            faction. Our purpose is to provide accurate civic information so that Haitians can make
-            their own informed decisions. Political questions belong to Haitian citizens, not to
-            civic technology platforms.
+            faction. Our purpose is to make official civic information easier to understand so that
+            Haitians can make their own informed decisions.
           </p>
         </section>
       </div>
 
       <div className="mt-12 flex flex-col gap-4 sm:flex-row">
-        <Link href="/eligibility" className={cn(buttonVariants(), 'sm:w-auto w-full')}>
+        <Link href="/eligibility" className={cn(buttonVariants(), 'w-full sm:w-auto')}>
           Check Your Eligibility
         </Link>
         <Link
-          href="/resources"
-          className={cn(buttonVariants({ variant: 'outline' }), 'sm:w-auto w-full')}
+          href="/timeline"
+          className={cn(buttonVariants({ variant: 'outline' }), 'w-full sm:w-auto')}
         >
-          Browse Resources
+          View the Election Timeline
         </Link>
       </div>
 
       <div className="mt-8 rounded-lg border border-muted-foreground/20 p-4 text-xs text-muted-foreground">
-        Sources: Haitian Constitution (1987), CEP public communications, Inter-American Commission
-        on Human Rights, United Nations Office for the Coordination of Humanitarian Affairs. This
-        page reflects best available information as of early 2025 and will be updated as the
-        electoral process develops.
+        <p>
+          This page reflects official information available on August 11, 2026. Election dates and
+          procedures may change.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">
+          <a
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            href={cepCalendarUrl}
+          >
+            Official CEP calendar
+          </a>
+          <a
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            href={cepUpdatesUrl}
+          >
+            Latest CEP notices
+          </a>
+        </div>
       </div>
     </article>
   )


### PR DESCRIPTION
## What changed

- Replaced the superseded August and December 2026 election dates with the CEP's official 2026-2027 schedule.
- Expanded the Timeline page with voter registration, political-party and alliance activity, accreditation, candidate registration, campaign, voting, and results milestones.
- Updated Why This Election Matters with recent CEP actions, the security and funding caveat, and more precise diaspora voting guidance.
- Added links to the official CEP calendar and current CEP notices.

## Why

The existing pages reflected the prior electoral calendar and described several now-active processes as pending. The CEP published a revised calendar on July 27, 2026 and has since issued operational updates.

## Impact

Visitors receive current, source-linked civic information and a clearer distinction between completed, active, scheduled, and conditional milestones.

## Validation

- `pnpm check:types`
- `pnpm test` — 24 tests passed
- `pnpm build` — completed successfully (existing repository warnings remain)